### PR TITLE
Fix failing test ( win11 )

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -56,22 +56,25 @@ export function timestampToLocalDatetime(timestamp?: number, locales?: Intl.Loca
 
   const date = new Date(timestamp);
 
-  return date.toLocaleDateString(locales, {
-    weekday: 'long',
-    year: '2-digit',
-    month: 'numeric',
-    day: 'numeric',
-    hour: 'numeric',
-    minute: 'numeric',
-  });
+ return date
+    .toLocaleDateString(locales, {
+      weekday: 'long',
+      year: '2-digit',
+      month: 'numeric',
+      day: 'numeric',
+      hour: 'numeric',
+      minute: 'numeric',
+    })
+    .replace(/\u202f/g, ' ');
 }
+
 
 if (import.meta.vitest) {
   const { it, expect } = import.meta.vitest;
 
   it('shows localized datetime', () => {
     expect(timestampToLocalDatetime(new Date(2024, 1, 10, 14, 30, 0).getTime(), 'en-US')).toBe(
-      'Saturday, 2/10/24, 2:30\u202fPM',
+      'Saturday, 2/10/24, 2:30 PM',
     );
     expect(timestampToLocalDatetime(new Date(2024, 1, 10, 14, 30, 0).getTime(), 'fr-FR')).toBe('samedi 10/02/24 14:30');
   });

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -71,7 +71,7 @@ if (import.meta.vitest) {
 
   it('shows localized datetime', () => {
     expect(timestampToLocalDatetime(new Date(2024, 1, 10, 14, 30, 0).getTime(), 'en-US')).toBe(
-      'Saturday, 2/10/24, 2:30 PM',
+      'Saturday, 2/10/24, 2:30\u202fPM',
     );
     expect(timestampToLocalDatetime(new Date(2024, 1, 10, 14, 30, 0).getTime(), 'fr-FR')).toBe('samedi 10/02/24 14:30');
   });


### PR DESCRIPTION
 FAIL  src/utils.ts > shows localized datetime
AssertionError: expected 'Saturday, 2/10/24, 2:30\u202fPM' to be 'Saturday, 2/10/24, 2:30 PM' // Object.is equality

- Expected
+ Received

- Saturday, 2/10/24, 2:30 PM
+ Saturday, 2/10/24, 2:30 PM

Simply changing the expected output worked for me. \u202f is known as " Narrow No-Break Space " , so maybe it can change depending on env? And maybe it's better to somehow define this in date.toLocaleDateString , but I did not immediately find that option