### PR TITLE
add broadcast email address to about section

### DIFF
--- a/src/components/Settings.vue
+++ b/src/components/Settings.vue
@@ -73,8 +73,11 @@ function logout() {
         >
       </p>
       <p class="mb-2 text-sm leading-6 text-gray-400">
-        If you're having trouble with your broadcast, please post to
-        <code class="font-bold">#support</code> on the
+        If you're having trouble with your broadcast, please contact
+        <a href="#" class="underline" @click.prevent="openPath('mailto:broadcast@lichess.org')"
+          >broadcast@lichess.org</a
+        >
+        or post to <code class="font-bold">#support</code> on the
         <a href="#" class="underline" @click.prevent="openPath('https://discord.gg/lichess')"> Lichess Discord</a>.
       </p>
 


### PR DESCRIPTION
not every user will have a discord account and the lichess broadcast email address has already been used for questions regarding the broadcaster app

![image](https://github.com/lichess-org/broadcaster/assets/142276609/4232a19a-5bbb-49d8-b5c3-5f96fd4dcddd)

(the sentence might be too long now)