### PR TITLE
Update OS file watcher to only handle writes

### DIFF
--- a/src/components/FolderWatcher.vue
+++ b/src/components/FolderWatcher.vue
@@ -72,6 +72,11 @@ function stopWatching() {
 }
 
 function handleFolderChange(event: WatchEvent): void {
+  console.log(event.type, event.paths);
+  if (event.type.access.mode !== 'write') {
+    return;
+  }
+
   if (event.paths.find(filename => isMultiGamePgn(filename))) {
     status.setRoundHasMultiGamePgn(props.round.round.id);
   }

--- a/src/components/FolderWatcher.vue
+++ b/src/components/FolderWatcher.vue
@@ -72,25 +72,23 @@ function stopWatching() {
 }
 
 function handleFolderChange(event: WatchEvent): void {
-  console.log(event.type, event.paths);
-  if (event.type.access.mode !== 'write') {
-    return;
+  const type = event.type;
+  if (typeof type !== 'string' && 'access' in type && 'mode' in type.access && type.access.mode === 'write') {
+    if (event.paths.find(filename => isMultiGamePgn(filename))) {
+      status.setRoundHasMultiGamePgn(props.round.round.id);
+    }
+
+    const toUpload = multiOrSingleFilter(event.paths);
+
+    if (toUpload.length === 0) {
+      return;
+    }
+
+    add_to_queue(props.round.round.id, toUpload);
+
+    const paths = toUpload.map(file => file.split('/').pop());
+    logs.info(`Modified: ${paths.join(', ')}`);
   }
-
-  if (event.paths.find(filename => isMultiGamePgn(filename))) {
-    status.setRoundHasMultiGamePgn(props.round.round.id);
-  }
-
-  const toUpload = multiOrSingleFilter(event.paths);
-
-  if (toUpload.length === 0) {
-    return;
-  }
-
-  add_to_queue(props.round.round.id, toUpload);
-
-  const paths = toUpload.map(file => file.split('/').pop());
-  logs.info(`Modified: ${paths.join(', ')}`);
 }
 
 async function resetAndReupload() {


### PR DESCRIPTION
In tauri v2, `tauri-plugin-fs-watch` plugin sends more file events and in a different structure. We only want to perform actions when a `write` occurs.

Fixes #51