### PR TITLE
Potential fix for code scanning alert no. 10: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: read
 
 on: [push, pull_request]
 


### PR DESCRIPTION
Potential fix for [https://github.com/lichess-org/broadcaster/security/code-scanning/10](https://github.com/lichess-org/broadcaster/security/code-scanning/10)

To fix the issue, explicitly declare the minimum required permissions for the workflow or individual jobs. Since none of the jobs in this workflow require write access, the minimal safe default is to set `permissions: contents: read` at the root of the workflow. This restricts the GITHUB_TOKEN to only read repository contents, following the principle of least privilege. This change should be made at the workflow root (directly under the `name: CI` line and before the `on:` block) in `.github/workflows/ci.yml`. No additional dependencies or code changes are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
