### PR TITLE
Potential fix for code scanning alert no. 8: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,4 +1,6 @@
 name: Rust
+permissions:
+  contents: read
 
 on: [push, pull_request]
 


### PR DESCRIPTION
Potential fix for [https://github.com/lichess-org/broadcaster/security/code-scanning/8](https://github.com/lichess-org/broadcaster/security/code-scanning/8)

The best way to fix this issue is to add a `permissions` block to the workflow. For maximum clarity and maintainability, it is standard to add this block at the top (root) of the workflow, right below the `name:` and before the `on:` (or anywhere before `jobs:`). Since the existing workflow does not seem to interact with the GitHub API for any write actions (e.g., publishing releases, commenting on PRs), the lowest level of permission, `contents: read`, should be used. This adheres to the principle of least privilege, ensuring the workflow jobs cannot write to the repository or perform unnecessary GitHub API actions.

To implement the change, insert the following block:
```yaml
permissions:
  contents: read
```
either after line 1 (`name: Rust`) or immediately above `jobs:` (line 8).

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
