### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/tauri-publish.yml
+++ b/.github/workflows/tauri-publish.yml
@@ -8,6 +8,8 @@ on:
 
 jobs:
   build:
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Potential fix for [https://github.com/lichess-org/broadcaster/security/code-scanning/2](https://github.com/lichess-org/broadcaster/security/code-scanning/2)

To fix the problem, we should explicitly set the `permissions` block at the workflow root (to apply to all jobs unless overridden), or at the individual job level where needed. Since the `build` job does not have a `permissions` block and the typical best practice is to assign the minimum permissions it needs, we should add a `permissions: contents: read` block to the `build` job. This will restrict the token to the minimum required for read access (such as accessing repository code), unless we know for a fact that additional permissions are necessary for `build`. The `publish` job already has `permissions: contents: write`, so no changes are needed there.

**What to change:**  
- At the same indentation level as `strategy:` in the `build` job, add:
  ```yaml
  permissions:
    contents: read
  ```
This goes right before `strategy:` (after line 10), as per YAML syntax and GitHub Actions conventions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
